### PR TITLE
[FIX] Make the Swedbank parser compatible with ofxstatement 0.7.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages
 from distutils.core import setup
 
-version = "1.3.2"
+version = "1.3.3"
 
 with open('README.rst') as f:
     long_description = f.read()

--- a/src/ofxstatement/plugins/swedbankLV.py
+++ b/src/ofxstatement/plugins/swedbankLV.py
@@ -74,7 +74,7 @@ class SwedbankLVCsvStatementParser(CsvStatementParser):
             return stmtline
 
         elif lineType == LINETYPE_ENDBALANCE:
-            self.statement.end_balance = self.parse_float(line[5])
+            self.statement.end_balance = self.parse_decimal(line[5])
             self.statement.end_date = self.parse_datetime(line[2])
 
             # DEBUG
@@ -82,15 +82,12 @@ class SwedbankLVCsvStatementParser(CsvStatementParser):
                 print("End balance: %s" % self.statement.end_balance)
 
         elif lineType == LINETYPE_STARTBALANCE and self.statement.start_balance == None:
-            self.statement.start_balance = self.parse_float(line[5])
+            self.statement.start_balance = self.parse_decimal(line[5])
             self.statement.start_date = self.parse_datetime(line[2])
 
             # DEBUG
             if self.debug:
                 print("Start balance: %s" % self.statement.start_balance)
-
-    def parse_float(self, value):
-        return value if isinstance(value, float) else float(value.replace(',', '.'))
 
 class SwedbankLVPlugin(Plugin):
     """Latvian Swedbank CSV"""


### PR DESCRIPTION
The parsing would fail in the assert_valid method because the `+` operator can't be used for float and Decimal variables (total amount).

```
$ ofxstatement convert -t swedbank statement\ \(2\).csv swedbank.ofx
Traceback (most recent call last):
  File "/home/miku/.local/bin/ofxstatement", line 8, in <module>
    sys.exit(run())
  File "/home/miku/.local/lib/python3.8/site-packages/ofxstatement/tool.py", line 195, in run
    return args.func(args)
  File "/home/miku/.local/lib/python3.8/site-packages/ofxstatement/tool.py", line 173, in convert
    statement.assert_valid()
  File "/home/miku/.local/lib/python3.8/site-packages/ofxstatement/statement.py", line 89, in assert_valid
    if not isclose(self.start_balance + total_amount, self.end_balance):
TypeError: unsupported operand type(s) for +: 'float' and 'decimal.Decimal'
```